### PR TITLE
Fix race condition produced by colliding filename

### DIFF
--- a/source/include/lib_usb_manager.php
+++ b/source/include/lib_usb_manager.php
@@ -1030,7 +1030,7 @@ function virsh_device_by_bus($action, $vmname, $usbbus, $usbdev)
 	</source>
 	</hostdev>";
 	}
-	$filename = '/tmp/libvirthotplugusbbybus'.$vmname.'.xml';
+	$filename = '/tmp/libvirthotplugusbbybus'.$vmname.'-'.$usbbus.'-'.$usbdev.'.xml';
 	file_put_contents($filename,$usbstr);
 	
 	$cmdreturn=shell_exec("/usr/sbin/virsh $action-device '$vmname' '".$filename."' 2>&1");


### PR DESCRIPTION
Full history here: https://forums.unraid.net/topic/100511-plugin-usb_manager/?do=findComment&comment=1128439

Improved fix version. Instead adding only the `usbdev` I added also the `usbbus` for even less chance of collision. 

Thanks for this plugin man. I really appreciate it, hence my collaboration to make it better :smile: 